### PR TITLE
Spring Security: JSON + JWT 기반 signup / login / logout 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// spring data jdbc, oracle, log4jdbc
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -50,7 +50,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
 	// spring security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 //	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
 	// OAuth2

--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,11 @@ dependencies {
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-//	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
-	// OAuth2
-//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// mark down
 	implementation 'org.commonmark:commonmark:0.21.0'

--- a/src/main/java/com/sesac/carematching/config/JsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/sesac/carematching/config/JsonUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,74 @@
+package com.sesac.carematching.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Data;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class JsonUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final String DEFAULT_LOGIN_REQUEST_URL = "/api/user/login";
+    private static final String HTTP_METHOD = "POST";
+    private static final String CONTENT_TYPE = "application/json"; // json 타입의 데이터만 허용
+    private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
+        new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URL, HTTP_METHOD); //=>   /login 의 요청에, POST로 온 요청에 매칭된다.
+
+    private final ObjectMapper objectMapper;
+
+    public JsonUsernamePasswordAuthenticationFilter(ObjectMapper objectMapper
+        , AuthenticationSuccessHandler authenticationSuccessHandler // 로그인 성공 시 처리할 핸들러
+        , AuthenticationFailureHandler authenticationFailureHandler // 로그인 실패 시 처리할 핸들러
+    ) {
+        super(DEFAULT_LOGIN_PATH_REQUEST_MATCHER);   // 위에서 설정한  /api/user/login/* 의 요청에, GET으로 온 요청을 처리하기 위해 설정한다.
+
+        this.objectMapper = objectMapper;
+        setAuthenticationSuccessHandler(authenticationSuccessHandler);
+        setAuthenticationFailureHandler(authenticationFailureHandler);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+
+        if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
+            throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
+        }
+
+        LoginDto loginDto = objectMapper.readValue(StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8), LoginDto.class);
+
+        String username = loginDto.getUsername();
+        String password = loginDto.getPassword();
+
+        if (username == null || password == null) {
+            throw new AuthenticationServiceException("DATA IS MISS");
+        }
+
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(username, password);
+        // Allow subclasses to set the "details" property
+        setDetails(request, authRequest);
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+
+    protected void setDetails(HttpServletRequest request, UsernamePasswordAuthenticationToken authRequest) {
+        authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+    }
+
+    @Data
+    private static class LoginDto {
+        String username;
+        String password;
+    }
+}

--- a/src/main/java/com/sesac/carematching/config/JsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/sesac/carematching/config/JsonUsernamePasswordAuthenticationFilter.java
@@ -47,10 +47,10 @@ public class JsonUsernamePasswordAuthenticationFilter extends AbstractAuthentica
             throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
         }
 
-        LoginDto loginDto = objectMapper.readValue(StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8), LoginDto.class);
+        LoginDTO loginDTO = objectMapper.readValue(StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8), LoginDTO.class);
 
-        String username = loginDto.getUsername();
-        String password = loginDto.getPassword();
+        String username = loginDTO.getUsername();
+        String password = loginDTO.getPassword();
 
         if (username == null || password == null) {
             throw new AuthenticationServiceException("DATA IS MISS");
@@ -67,7 +67,7 @@ public class JsonUsernamePasswordAuthenticationFilter extends AbstractAuthentica
     }
 
     @Data
-    private static class LoginDto {
+    private static class LoginDTO {
         String username;
         String password;
     }

--- a/src/main/java/com/sesac/carematching/config/JwtUtil.java
+++ b/src/main/java/com/sesac/carematching/config/JwtUtil.java
@@ -1,0 +1,61 @@
+package com.sesac.carematching.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    public String generateToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        String role = userDetails.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse("ROLE_USER");
+
+        claims.put("role", role);
+        claims.put("username", userDetails.getUsername());
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 48)) // 48시간 유지
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validateToken(String token, UserDetails userDetails) {
+        final String username = extractUsername(token);
+        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+
+    public String extractUsername(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    private Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractClaims(token).getExpiration().before(new Date());
+    }
+}

--- a/src/main/java/com/sesac/carematching/config/LoginFailureHandler.java
+++ b/src/main/java/com/sesac/carematching/config/LoginFailureHandler.java
@@ -1,0 +1,40 @@
+package com.sesac.carematching.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("status", "error");
+        errorResponse.put("message", "로그인에 실패했습니다.");
+        errorResponse.put("error", exception.getMessage());
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/src/main/java/com/sesac/carematching/config/LoginSuccessHandler.java
+++ b/src/main/java/com/sesac/carematching/config/LoginSuccessHandler.java
@@ -1,0 +1,46 @@
+package com.sesac.carematching.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                      Authentication authentication) throws IOException, ServletException {
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        String token = jwtUtil.generateToken(userDetails);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("token", token);
+        responseBody.put("username", userDetails.getUsername());
+        String role = userDetails.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse("ROLE_USER");
+        responseBody.put("role", role);
+
+        objectMapper.writeValue(response.getWriter(), responseBody);
+    }
+}

--- a/src/main/java/com/sesac/carematching/config/SecurityConfig.java
+++ b/src/main/java/com/sesac/carematching/config/SecurityConfig.java
@@ -1,0 +1,79 @@
+package com.sesac.carematching.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf
+//                .ignoringRequestMatchers(new AntPathRequestMatcher("/h2-console/**"))
+                .ignoringRequestMatchers(new AntPathRequestMatcher("/board/like"))
+                .ignoringRequestMatchers(new AntPathRequestMatcher("/users/myPage/verify-password"))
+                .ignoringRequestMatchers(new AntPathRequestMatcher("/users/change-nickname"))
+                .ignoringRequestMatchers(new AntPathRequestMatcher("/users/change-password"))
+                .ignoringRequestMatchers(new AntPathRequestMatcher("/api/scrap/**"))
+            )
+            .securityMatcher("/users/**", "/board/**", "/reply/**", "/api/**", "/oauth2/**", "/login/**", "/scrap/**")
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/users/signup", "/users/check-username", "/users/check-nickname", "/users/login", "/users/check-auth",  // 로그인 및 회원가입 페이지, 권한 확인은 누구나 접근 가능
+                    "/board/infolist", "/board/generallist", "/board/qnalist", "/board/menu", // 게시판 목록 누구나 접근 가능
+                    "/map/**", "/api/**", "/oauth2/**", "/login/**")
+                .permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                .loginPage("/users/login")
+                .loginProcessingUrl("/users/login")
+                .successHandler((request, response, authentication) -> {
+                    // 로그인 성공 시 이전 요청한 페이지로 이동
+                    var savedRequest = (SavedRequest) request.getSession()
+                        .getAttribute("SPRING_SECURITY_SAVED_REQUEST");
+                    if (savedRequest != null) {
+                        response.sendRedirect(savedRequest.getRedirectUrl());
+                    } else {
+                        response.sendRedirect("/map");
+                    }
+                })
+                .failureUrl("/users/login?error=true") // 실패 시 로그인 페이지로 리다이렉트
+                .permitAll()
+            )
+
+            .logout(logout -> logout
+                .logoutRequestMatcher(new AntPathRequestMatcher("/users/logout"))
+                .logoutSuccessUrl("/map")
+                .invalidateHttpSession(true)
+                .clearAuthentication(true)
+                .permitAll()
+            )
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(
+                    (request, response, authException) -> response.sendRedirect("/users/login")
+                )
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/sesac/carematching/user/CustomUserDetails.java
+++ b/src/main/java/com/sesac/carematching/user/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package com.sesac.carematching.user;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private String username;
+    private String password;
+
+    @Getter
+    private String nickname;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(String username, String password, String nickname,
+                             List<GrantedAuthority> authorities) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.authorities = authorities;
+    }
+
+    // UserDetails 메서드 구현
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+    @Override
+    public String getPassword() {
+        return password;
+    }
+    @Override
+    public String getUsername() {
+        return username;
+    }
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/sesac/carematching/user/User.java
+++ b/src/main/java/com/sesac/carematching/user/User.java
@@ -1,10 +1,12 @@
 package com.sesac.carematching.user;
 
+import com.sesac.carematching.caregiver.Caregiver;
 import com.sesac.carematching.user.role.Role;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
@@ -16,6 +18,7 @@ import java.time.Instant;
 @Setter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
 @Table(name = "user")
 public class User {
     @Id
@@ -38,6 +41,11 @@ public class User {
     @Column(name = "PASSWORD", nullable = false)
     private String password;
 
+    @Size(max = 50)
+    @NotNull
+    @Column(name = "NICKNAME", nullable = false, length = 50)
+    private String nickname;
+
     @Size(max = 12)
     @Column(name = "PHONE", length = 12)
     private String phone;
@@ -55,5 +63,15 @@ public class User {
     @CreatedDate
     @Column(name = "CREATED_AT", nullable = false)
     private Instant createdAt;
+
+    @OneToOne(mappedBy = "user")
+    private Caregiver caregiver;
+
+    public User(String username, String password, String nickname, Role role) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.role = role;
+    }
 
 }

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -1,0 +1,18 @@
+package com.sesac.carematching.user;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/users")
+public class UserController {
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> join(@RequestBody User user) {
+        System.out.println("회원가입 컨트롤러 실행" + user);
+        userService.joinUser(user);
+        System.out.println("회원가입 완료");
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -1,18 +1,57 @@
 package com.sesac.carematching.user;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/users")
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
 public class UserController {
 
+    private final UserService userService;
+
     @PostMapping("/signup")
-    public ResponseEntity<Void> join(@RequestBody User user) {
+    public ResponseEntity<Void> join(@RequestBody UserSignupDTO user) {
         System.out.println("회원가입 컨트롤러 실행" + user);
-        userService.joinUser(user);
+        userService.registerUser(user);
         System.out.println("회원가입 완료");
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/loginOk")
+    public ResponseEntity<Map<String, String>> loginOk() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+        String authorities = authentication.getAuthorities().toString();
+
+        Map<String, String> response = new HashMap<>();
+        response.put("email", username);
+        response.put("authorities", authorities);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/logoutOk")
+    public ResponseEntity<Void> logoutOk() {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<User> getUserPage() {
+        System.out.println("일반 인증 성공");
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        // 유저 정보
+        User user = userService.getUserInfo(username);
+
+        return ResponseEntity.ok(user);
     }
 }

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -1,13 +1,20 @@
 package com.sesac.carematching.user;
 
+import com.sesac.carematching.config.JwtUtil;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,6 +22,7 @@ import java.util.Map;
 public class UserController {
 
     private final UserService userService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/signup")
     public ResponseEntity<Void> join(@RequestBody UserSignupDTO user) {
@@ -53,5 +61,30 @@ public class UserController {
         User user = userService.getUserInfo(username);
 
         return ResponseEntity.ok(user);
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteAccount(HttpServletRequest request) {
+        // JWT 토큰에서 사용자 정보 추출
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 토큰이 필요합니다.");
+        }
+
+        String token = authHeader.substring(7);
+        String username = jwtUtil.extractUsername(token);
+
+        if (username == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+
+        try {
+            userService.deleteUser(username);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("회원 탈퇴 처리 중 오류가 발생했습니다.");
+        }
     }
 }

--- a/src/main/java/com/sesac/carematching/user/UserRepository.java
+++ b/src/main/java/com/sesac/carematching/user/UserRepository.java
@@ -1,0 +1,7 @@
+package com.sesac.carematching.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+}

--- a/src/main/java/com/sesac/carematching/user/UserRepository.java
+++ b/src/main/java/com/sesac/carematching/user/UserRepository.java
@@ -1,7 +1,10 @@
 package com.sesac.carematching.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByUsername(String username);
+    Optional<User> findByNickname(String nickname);
+    void deleteByUsername(String username);
 }

--- a/src/main/java/com/sesac/carematching/user/UserSecurityService.java
+++ b/src/main/java/com/sesac/carematching/user/UserSecurityService.java
@@ -1,0 +1,38 @@
+package com.sesac.carematching.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class UserSecurityService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    // Role 엔티티의 지연 로딩이 설정된 상태라 @Transactional을 설정해줘야 된다고 함.
+    // Lazy 로딩말고 Eager로 바꾸는게 더 좋을지... User 엔티티를 불러올 때 Role을 불러오는 것이 좋을까???
+    @Transactional
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> _user = this.userRepository.findByUsername(username);
+        if (_user.isEmpty()) {
+            throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
+        }
+        User user = _user.get();
+        List<GrantedAuthority> authorities = new ArrayList<>();
+
+        authorities.add(new SimpleGrantedAuthority(user.getRole().getRname()));
+
+        return new CustomUserDetails(user.getUsername(), user.getPassword(), user.getNickname(), authorities);
+    }
+}

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -1,0 +1,5 @@
+package com.sesac.carematching.user;
+
+public class UserService {
+
+}

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -1,5 +1,74 @@
 package com.sesac.carematching.user;
 
+import com.sesac.carematching.user.role.RoleService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
 public class UserService {
 
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private final RoleService roleService;
+
+    // 회원가입 로직
+    public void registerUser(UserSignupDTO dto) {
+
+        if(userRepository.findByUsername(dto.getUsername()).isPresent()){
+            throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
+        }
+
+        // 비밀번호 확인
+        if (!dto.getPassword().equals(dto.getConfirmPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 아이디 중복 확인
+        if (!isUsernameAvailable(dto.getUsername())) {
+            throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+        }
+
+        // 닉네임 중복 확인
+        if (!isNicknameAvailable(dto.getNickname())) {
+            throw new IllegalArgumentException("이미 있는 닉네임입니다.");
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(dto.getPassword());
+
+        // Users 객체 생성
+        User user = new User(
+            dto.getUsername(),
+            encodedPassword, // 암호화된 비밀번호 저장
+            dto.getNickname(),
+            roleService.findRoleByName("ROLE_USER")
+        );
+
+        // 사용자 저장
+        userRepository.save(user);
+    }
+
+    public User getUserInfo(String username) {
+        return userRepository.findByUsername(username).orElse(null);
+    }
+
+    // 아이디 중복 확인
+    public boolean isUsernameAvailable(String username) {
+        return userRepository.findByUsername(username).isEmpty();
+    }
+
+    // 닉네임 중복 확인
+    public boolean isNicknameAvailable(String nickname) {
+        return userRepository.findByNickname(nickname).isEmpty();
+    }
+
+    // 회원 탈퇴
+    @Transactional
+    public void deleteUser(String username){
+        userRepository.deleteByUsername(username);
+    }
 }

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -68,7 +68,11 @@ public class UserService {
 
     // 회원 탈퇴
     @Transactional
-    public void deleteUser(String username){
-        userRepository.deleteByUsername(username);
+    public void deleteUser(String username) {
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // 연관된 데이터들은 JPA 엔티티에서 @OnDelete(action = OnDeleteAction.CASCADE) 설정으로 자동 삭제됨
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/com/sesac/carematching/user/UserSignupDTO.java
+++ b/src/main/java/com/sesac/carematching/user/UserSignupDTO.java
@@ -1,0 +1,19 @@
+package com.sesac.carematching.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UserSignupDTO {
+    @NotBlank(message = "아이디는 필수 입력 항목입니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수 입력 항목입니다.")
+    private String confirmPassword;
+
+    @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+    private String nickname;
+}

--- a/src/main/java/com/sesac/carematching/user/role/Role.java
+++ b/src/main/java/com/sesac/carematching/user/role/Role.java
@@ -16,7 +16,6 @@ public class Role {
     private Integer id;
 
     @Size(max = 30)
-    @Column(name = "RNAME", length = 30)
+    @Column(name = "RNAME", length = 30, unique = true)
     private String rname;
-
 }

--- a/src/main/java/com/sesac/carematching/user/role/RoleRepository.java
+++ b/src/main/java/com/sesac/carematching/user/role/RoleRepository.java
@@ -1,0 +1,7 @@
+package com.sesac.carematching.user.role;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Integer> {
+    public Role findByRname(String rname);
+}

--- a/src/main/java/com/sesac/carematching/user/role/RoleService.java
+++ b/src/main/java/com/sesac/carematching/user/role/RoleService.java
@@ -1,0 +1,14 @@
+package com.sesac.carematching.user.role;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoleService {
+    private final RoleRepository roleRepository;
+
+    public Role findRoleByName(String name) {
+        return roleRepository.findByRname(name);
+    }
+}


### PR DESCRIPTION
React(Nginx 서버)와 Spring boot 서버를 개별적으로 실행할 예정이다보니 세션기반 인증은 힘든 상황이라 JWT 토큰을 사용하게 됐네요.

또, React는 JSON을 다루는게 훨씬 유용해서 JSON 형식으로 서로 통신하도록 했습니다.

### JWT 의존성 패키지 추가
```
implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
```

### USER 테이블에 `Nickname` 칼럼 추가

사용자 ID가 보여지는 것보다는 닉네임을 설정할 수 있으면 좋을 것 같아 추가했습니다.
사용자 이름은 username이 아닌 nickname을 보여주도록 하죠.

### CAREGIVER 테이블에 `Name` (실명) 칼럼 추가할지

요양사를 구할 때는 아무래도 실명을 확인할 수 있기를 원하지 않을까 싶네요.

### User 엔티티 관련

Role 엔티티와 `@ManyToOne` 으로 매칭된 상황인데 `Lazy` 로딩을 사용하고 있어, Role의 정보가 필요할 때는 `@Transactional`을 걸어서 하나의 트랜잭션으로 묶어줘야 하는 것 같음. User 엔티티를 불러올 때 Role의 이름을 항상 불러오는 것이 더 나을까요? User 엔티티를 사용할 때 Role을 자주 사용할지 모르겠네요. 저는 그런 상황이 거의 없다고 판단하고 있어요.

### Role 엔티티 관련

Rname에 unique 조건을 추가했습니다. 현재 기획으로는 역할 이름이 겹치는 안되는 상황이라고 생각해요.

### 추가 구현이 필요한 부분

1. 회원 탈퇴 기능