### PR TITLE
유저 프로필 수정 기능 추가

### DIFF
--- a/src/main/java/com/sesac/carematching/user/UserRepository.java
+++ b/src/main/java/com/sesac/carematching/user/UserRepository.java
@@ -6,5 +6,4 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByUsername(String username);
     Optional<User> findByNickname(String nickname);
-    void deleteByUsername(String username);
 }

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -75,4 +75,32 @@ public class UserService {
         // 연관된 데이터들은 JPA 엔티티에서 @OnDelete(action = OnDeleteAction.CASCADE) 설정으로 자동 삭제됨
         userRepository.delete(user);
     }
+
+    @Transactional
+    public void updateUser(String username, UserUpdateDTO dto) {
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (!passwordEncoder.matches(dto.getCurrentPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (dto.getNewPassword() != null && !dto.getNewPassword().equals(dto.getConfirmPassword())) {
+            throw new IllegalArgumentException("새 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (dto.getNickname() != null && !dto.getNickname().isEmpty()) {
+            user.setNickname(dto.getNickname());
+        }
+
+        if (dto.getPhoneNumber() != null && !dto.getPhoneNumber().isEmpty()) {
+            user.setPhone(dto.getPhoneNumber());
+        }
+
+        if (dto.getNewPassword() != null && !dto.getNewPassword().isEmpty()) {
+            user.setPassword(passwordEncoder.encode(dto.getNewPassword()));
+        }
+
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/sesac/carematching/user/UserSignupDTO.java
+++ b/src/main/java/com/sesac/carematching/user/UserSignupDTO.java
@@ -1,19 +1,24 @@
 package com.sesac.carematching.user;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class UserSignupDTO {
     @NotBlank(message = "아이디는 필수 입력 항목입니다.")
+    @Size(max = 50, message = "아이디는 최대 50자까지 가능합니다.")
     private String username;
 
     @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Size(max = 255, message = "비밀번호는 최대 255자까지 가능합니다.")
     private String password;
 
     @NotBlank(message = "비밀번호 확인은 필수 입력 항목입니다.")
+    @Size(max = 255, message = "비밀번호는 최대 255자까지 가능합니다.")
     private String confirmPassword;
 
     @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+    @Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
     private String nickname;
 }

--- a/src/main/java/com/sesac/carematching/user/UserUpdateDTO.java
+++ b/src/main/java/com/sesac/carematching/user/UserUpdateDTO.java
@@ -1,0 +1,24 @@
+package com.sesac.carematching.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class UserUpdateDTO {
+    @NotBlank(message = "현재 비밀번호는 필수 입력 항목입니다.")
+    @Size(max = 255, message = "비밀번호는 최대 255자까지 가능합니다.")
+    private String currentPassword;
+
+    @Size(max = 255, message = "새 비밀번호는 최대 255자까지 가능합니다.")
+    private String newPassword;
+
+    @Size(max = 255, message = "비밀번호 확인은 최대 255자까지 가능합니다.")
+    private String confirmPassword;
+
+    @Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
+    private String nickname;
+
+    @Size(max = 12, message = "전화번호는 최대 12자까지 가능합니다.")
+    private String phoneNumber;
+}


### PR DESCRIPTION
- `UserUpdateDTO`로 유저 프로필 수정 Reqeust를 받음
- `UserController`에서 POST 형식으로 `/update` 요청을 받음
- `UserService`에서 유저 프로필 업데이트 로직 실행
- DTO에 Size 검증 추가 - 데이터베이스 제약 조건과 동일하게 적용
- JWT 토큰 추출 로직 모듈화 (`UserController`)
- `UserController`에 HTTP 에러 핸들링 추가