### PR TITLE
개발환경과 운영환경 분리

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,7 @@ indent_size = 2
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@
 `java -Dspring.profiles.active=prod -jar app.jar"`
 
 ### 환경 변수를 통해 옵션 주기
-`SPRING_PROFILES_ACTIVE=dev` 를 .env 파일에 추가하거나  
+`SPRING_PROFILES_ACTIVE=prod` 를 .env 파일에 추가하거나  
 환경 변수에 적용해주면 된다.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+## Production 환경으로 실행
+
+### Java 명령어를 통해 직접 옵션 주기
+`java -Dspring.profiles.active=prod -jar app.jar"`
+
+### 환경 변수를 통해 옵션 주기
+`SPRING_PROFILES_ACTIVE=dev` 를 .env 파일에 추가하거나  
+환경 변수에 적용해주면 된다.

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 2
+      idle-timeout: 300000
+      connection-timeout: 20000
+      max-lifetime: 1200000
+
+logging:
+  level:
+    jdbc:
+      audit: DEBUG
+      sqlonly: DEBUG
+      resultset: DEBUG
+      resultsettable: DEBUG

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      idle-timeout: 300000
+      connection-timeout: 20000
+      max-lifetime: 1200000
+
+logging:
+  level:
+    jdbc:
+      audit: INFO
+      sqlonly: INFO
+      resultset: INFO
+      resultsettable: INFO

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     hikari:
-      maximum-pool-size: 20
-      minimum-idle: 5
+      maximum-pool-size: 5
+      minimum-idle: 3
       idle-timeout: 300000
       connection-timeout: 20000
       max-lifetime: 1200000

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   application:
     name: carematching
   config:
@@ -30,13 +32,6 @@ spring:
 mybatis:
   type-aliases-package: com.sesac.carematching
   mapper-locations: classpath:mapper/**/*.xml
-logging:
-  level:
-    jdbc:
-      audit: DEBUG
-      sqlonly: DEBUG
-      resultset: DEBUG
-      resultsettable: DEBUG
 
 springdoc:
   api-docs:


### PR DESCRIPTION
MariaDB 커넥션을 효율적으로 관리하기 위해서 **개발 환경과 운영 환경에 따른 설정을 분리했습니다.**
(계산 결과 현재 AWS RDS MariaDB의 최대 커넥션 수는 42개인데, 4명이서 개발할 때 10개씩 나눠서 40개로 딱 맞을 수도 있지만 운영환경까지 같이 고려하면 커넥션이 부족함.)
MariaDB 커넥션 문제가 아니더라도 개발 환경과 운영 환경의 설정이 달라지는 경우는 앞으로도 추가될 수 있다고 생각해서 전반적인 개발환경 설정과 운영환경 설정을 만들었어요.

application.yaml에 기본 환경을 dev로 해놨는데, environment variable로도 현재 환경을 설정할 수 있어요. 현재로선 대부분이 개발환경으로 실행되기 때문에 기본값을 dev로 지정했습니다. 추후 변경이 필요하다면 바꿔도 좋습니다.