### PR TITLE
add health check (/api/health)

### DIFF
--- a/src/main/java/com/sesac/carematching/config/SecurityConfig.java
+++ b/src/main/java/com/sesac/carematching/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
             .formLogin(AbstractHttpConfigurer::disable);
 
         http.authorizeHttpRequests(auth -> auth
-            .requestMatchers("/api/user/login", "/api/user/signup", "/api/**").permitAll()
+            .requestMatchers("/api/user/login", "/api/user/signup", "/api/health", "/api/**").permitAll()
             .anyRequest().authenticated());
 
         http.addFilterBefore(jsonUsernamePasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
+++ b/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
@@ -1,0 +1,32 @@
+package com.sesac.carematching.monitoring;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/health")
+public class HealthCheckController {
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> healthCheck() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "UP");
+        response.put("timestamp", new Date());
+
+        // 시스템 정보
+        Runtime runtime = Runtime.getRuntime();
+        response.put("memory", Map.of(
+            "total", runtime.totalMemory(),
+            "free", runtime.freeMemory(),
+            "used", runtime.totalMemory() - runtime.freeMemory()
+        ));
+
+        return ResponseEntity.ok(response);
+    }
+}


### PR DESCRIPTION
AWS에서 서버가 살아있는지 확인하기 위한 엔드포인트 추가

`/api/health` 에 요청하면
`{"memory":{"used":48495760,"total":77594624,"free":29098864},"status":"UP","timestamp":"2025-02-26T08:18:31.345+00:00"}`
위와 같이 메모리 정보와 현재 status를 "UP"으로 보여줍니다.