### PR TITLE
관리자의 요양사 인증 기능 추가 및 TokenAuth 수정

### DIFF
--- a/src/main/java/com/sesac/carematching/user/User.java
+++ b/src/main/java/com/sesac/carematching/user/User.java
@@ -55,7 +55,7 @@ public class User {
     private String certno;
 
     @NotNull
-    @ColumnDefault("0")
+    @ColumnDefault("1")
     @Column(name = "PENDING", nullable = false)
     private Boolean pending = false;
 

--- a/src/main/java/com/sesac/carematching/user/User.java
+++ b/src/main/java/com/sesac/carematching/user/User.java
@@ -55,9 +55,9 @@ public class User {
     private String certno;
 
     @NotNull
-    @ColumnDefault("1")
+    @ColumnDefault("true")
     @Column(name = "PENDING", nullable = false)
-    private Boolean pending = false;
+    private Boolean pending = true;
 
     @NotNull
     @CreatedDate

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import util.TokenAuth;
+import com.sesac.carematching.util.TokenAuth;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +23,7 @@ public class UserController {
 
     private final UserService userService;
     private final JwtUtil jwtUtil;
-    private TokenAuth tokenAuth;
+    private final TokenAuth tokenAuth;
 
     @PostMapping("/signup")
     public ResponseEntity<Void> join(@RequestBody UserSignupDTO user) {

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -51,24 +51,8 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    private String extractUsernameFromToken(HttpServletRequest request) {
-        String authHeader = request.getHeader("Authorization");
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("인증 토큰이 필요합니다.");
-        }
-
-        String token = authHeader.substring(7);
-        String username = jwtUtil.extractUsername(token);
-
-        if (username == null) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
-        }
-
-        return username;
-    }
-
     private void checkAdminPrivileges(HttpServletRequest request) {
-        User requestedUser = userService.getUserInfo(extractUsernameFromToken(request));
+        User requestedUser = userService.getUserInfo(tokenAuth.extractUsernameFromToken(request));
         if (requestedUser == null || !requestedUser.getRole().getRname().equals("ROLE_ADMIN")) {
             throw new IllegalArgumentException("관리자 전용 기능입니다.");
         }

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -1,6 +1,9 @@
 package com.sesac.carematching.user;
 
 import com.sesac.carematching.config.JwtUtil;
+import com.sesac.carematching.user.dto.UserSignupDTO;
+import com.sesac.carematching.user.dto.UserUpdateDTO;
+import com.sesac.carematching.user.dto.UsernameDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -101,6 +104,21 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body("회원 정보 수정 중 오류가 발생했습니다.");
         }
+    }
+
+    @PostMapping("/admin/cert")
+    public ResponseEntity<?> createAdminCert(HttpServletRequest request) {
+        return ResponseEntity.ok(userService.getCertList());
+    }
+
+    @PostMapping("/admin/cert/approve")
+    public ResponseEntity<?> createAdminCertApprove(@RequestBody UsernameDTO usernameDTO, HttpServletRequest request) {
+        return ResponseEntity.ok(userService.updatePending(usernameDTO, false));
+    }
+
+    @PostMapping("/admin/cert/revoke")
+    public ResponseEntity<?> createAdminCertRevoke(@RequestBody UsernameDTO usernameDTO, HttpServletRequest request) {
+        return ResponseEntity.ok(userService.updatePending(usernameDTO, true));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -22,7 +22,6 @@ public class UserController {
 
     private final UserService userService;
     private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
 
     @PostMapping("/signup")
     public ResponseEntity<Void> join(@RequestBody UserSignupDTO user) {
@@ -50,19 +49,6 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/user")
-    public ResponseEntity<User> getUserPage() {
-        System.out.println("일반 인증 성공");
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String username = authentication.getName();
-
-        // 유저 정보
-        User user = userService.getUserInfo(username);
-
-        return ResponseEntity.ok(user);
-    }
-
     private String extractUsernameFromToken(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
@@ -80,7 +66,7 @@ public class UserController {
     }
 
     private void checkAdminPrivileges(HttpServletRequest request) {
-        User requestedUser = userRepository.findByUsername(extractUsernameFromToken(request)).orElse(null);
+        User requestedUser = userService.getUserInfo(extractUsernameFromToken(request));
         if (requestedUser == null || !requestedUser.getRole().getRname().equals("ROLE_ADMIN")) {
             throw new IllegalArgumentException("관리자 전용 기능입니다.");
         }

--- a/src/main/java/com/sesac/carematching/user/UserRepository.java
+++ b/src/main/java/com/sesac/carematching/user/UserRepository.java
@@ -1,10 +1,15 @@
 package com.sesac.carematching.user;
 
+import com.sesac.carematching.user.dto.UserCertListDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByUsername(String username);
     Optional<User> findByNickname(String nickname);
+    @Query("SELECT new com.sesac.carematching.user.dto.UserCertListDTO(u.username, u.nickname, u.certno, u.pending) FROM User u WHERE u.certno IS NOT NULL")
+    List<UserCertListDTO> findCert();
 }

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -126,13 +126,9 @@ public class UserService {
 
         user.setPending(pending);
 
-        User savedUser = userRepository.save(user);
+        userRepository.save(user);
 
-        if (savedUser != null) {
-            return 0; // 성공
-        } else {
-            return 1; // 실패
-        }
+        return 0;
     }
 
 }

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -4,6 +4,7 @@ import com.sesac.carematching.user.dto.UserCertListDTO;
 import com.sesac.carematching.user.dto.UserSignupDTO;
 import com.sesac.carematching.user.dto.UserUpdateDTO;
 import com.sesac.carematching.user.dto.UsernameDTO;
+import com.sesac.carematching.user.role.Role;
 import com.sesac.carematching.user.role.RoleService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -125,6 +126,10 @@ public class UserService {
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
         user.setPending(pending);
+        if (pending)
+            user.setRole(roleService.findRoleByName("ROLE_USER"));
+        else
+            user.setRole(roleService.findRoleByName("ROLE_USER_CAREGIVER"));
 
         userRepository.save(user);
 

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -1,10 +1,16 @@
 package com.sesac.carematching.user;
 
+import com.sesac.carematching.user.dto.UserCertListDTO;
+import com.sesac.carematching.user.dto.UserSignupDTO;
+import com.sesac.carematching.user.dto.UserUpdateDTO;
+import com.sesac.carematching.user.dto.UsernameDTO;
 import com.sesac.carematching.user.role.RoleService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -101,6 +107,32 @@ public class UserService {
             user.setPassword(passwordEncoder.encode(dto.getNewPassword()));
         }
 
+        if (dto.getCertno() != null && !dto.getCertno().isEmpty()) {
+            user.setCertno(dto.getCertno());
+        }
+
         userRepository.save(user);
     }
+
+    @Transactional
+    public List<UserCertListDTO> getCertList() {
+        return userRepository.findCert();
+    }
+
+    @Transactional
+    public int updatePending(UsernameDTO usernameDTO, boolean pending) {
+        User user = userRepository.findByUsername(usernameDTO.getUsername())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        user.setPending(pending);
+
+        User savedUser = userRepository.save(user);
+
+        if (savedUser != null) {
+            return 0; // 성공
+        } else {
+            return 1; // 실패
+        }
+    }
+
 }

--- a/src/main/java/com/sesac/carematching/user/dto/UserCertListDTO.java
+++ b/src/main/java/com/sesac/carematching/user/dto/UserCertListDTO.java
@@ -1,0 +1,18 @@
+package com.sesac.carematching.user.dto;
+
+import lombok.Data;
+
+@Data
+public class UserCertListDTO {
+    private String username;
+    private String nickname;
+    private String certno;
+    private boolean pending;
+
+    public UserCertListDTO(String username, String nickname, String certno, boolean pending) {
+        this.username = username;
+        this.nickname = nickname;
+        this.certno = certno;
+        this.pending = pending;
+    }
+}

--- a/src/main/java/com/sesac/carematching/user/dto/UserSignupDTO.java
+++ b/src/main/java/com/sesac/carematching/user/dto/UserSignupDTO.java
@@ -1,4 +1,4 @@
-package com.sesac.carematching.user;
+package com.sesac.carematching.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/sesac/carematching/user/dto/UserUpdateDTO.java
+++ b/src/main/java/com/sesac/carematching/user/dto/UserUpdateDTO.java
@@ -1,4 +1,4 @@
-package com.sesac.carematching.user;
+package com.sesac.carematching.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -21,4 +21,7 @@ public class UserUpdateDTO {
 
     @Size(max = 12, message = "전화번호는 최대 12자까지 가능합니다.")
     private String phoneNumber;
+
+    @Size(max = 12, message = "자격증 정보는 최대 30자까지 입력 가능합니다.")
+    private String certno;
 }

--- a/src/main/java/com/sesac/carematching/user/dto/UsernameDTO.java
+++ b/src/main/java/com/sesac/carematching/user/dto/UsernameDTO.java
@@ -1,0 +1,8 @@
+package com.sesac.carematching.user.dto;
+
+import lombok.Data;
+
+@Data
+public class UsernameDTO {
+    String username;
+}

--- a/src/main/java/com/sesac/carematching/util/TokenAuth.java
+++ b/src/main/java/com/sesac/carematching/util/TokenAuth.java
@@ -1,10 +1,12 @@
-package util;
+package com.sesac.carematching.util;
 
 import com.sesac.carematching.config.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
+@Component
 public class TokenAuth {
     private final JwtUtil jwtUtil;
 


### PR DESCRIPTION
## User 엔티티 PENDING 칼럼 기본값 변경
PENDING을 기본값 TRUE로 변경함. 일단 모든 사용자는 자격증 정보를 입력하지 않은 상태이므로, CAREGIVER 인증이 완료되면 PENDING을 1로 변경해줌.

## TokenAuth 클래스
### 올바른 위치로 변경
java 소스코드 루트에 util 패키지를 만들었던 것을 `com.sesac.carematching` 아래로 옮김.

### `@Component`로 Bean 생성
TokenAuth를 Bean으로 만들어서 주입함.