### PR TITLE
Spring Security Session 사용 중지

### DIFF
--- a/src/main/java/com/sesac/carematching/config/SecurityConfig.java
+++ b/src/main/java/com/sesac/carematching/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -55,6 +56,10 @@ public class SecurityConfig {
 
         http.addFilterBefore(jsonUsernamePasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
+        http.sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+        
         return http.build();
     }
 


### PR DESCRIPTION
Token 기반 인증 방식은 세션과 별개로 Stateless한 인증방식인데
Session은 특별한 설정을 하지 않으면 그대로 사용을 유지하더라고요.

사용하지 않도록 하려면 `SessionCreationPolicy.STATELESS`로 설정해야 해요.