### PR TITLE
JWT 토큰 인증 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,12 +57,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// mark down
-	implementation 'org.commonmark:commonmark:0.21.0'
-
-	// mybatis
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-
     // Springdoc-openapi
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
 }

--- a/src/main/java/com/sesac/carematching/config/JwtUtil.java
+++ b/src/main/java/com/sesac/carematching/config/JwtUtil.java
@@ -49,11 +49,6 @@ public class JwtUtil {
                 .compact();
     }
 
-    public boolean validateToken(String token, UserDetails userDetails) {
-        final String username = extractUsername(token);
-        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
-    }
-
     public String extractUsername(String token) {
         return extractClaims(token).getSubject();
     }
@@ -64,9 +59,5 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
-    }
-
-    private boolean isTokenExpired(String token) {
-        return extractClaims(token).getExpiration().before(new Date());
     }
 }

--- a/src/main/java/com/sesac/carematching/config/JwtUtil.java
+++ b/src/main/java/com/sesac/carematching/config/JwtUtil.java
@@ -2,7 +2,6 @@ package com.sesac.carematching.config;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
@@ -10,10 +9,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Base64;
 
 @Component
 public class JwtUtil {

--- a/src/main/java/com/sesac/carematching/config/WebConfig.java
+++ b/src/main/java/com/sesac/carematching/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.sesac.carematching.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -79,7 +79,7 @@ public class UserController {
             userService.updateUser(username, userUpdateDTO);
             return ResponseEntity.ok().build();
         } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body("회원 정보 수정 중 오류가 발생했습니다.");

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -4,7 +4,6 @@ import com.sesac.carematching.user.dto.UserCertListDTO;
 import com.sesac.carematching.user.dto.UserSignupDTO;
 import com.sesac.carematching.user.dto.UserUpdateDTO;
 import com.sesac.carematching.user.dto.UsernameDTO;
-import com.sesac.carematching.user.role.Role;
 import com.sesac.carematching.user.role.RoleService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sesac/carematching/util/TokenAuth.java
+++ b/src/main/java/com/sesac/carematching/util/TokenAuth.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import io.jsonwebtoken.ExpiredJwtException;
+
 @RequiredArgsConstructor
 @Component
 public class TokenAuth {
@@ -17,7 +19,12 @@ public class TokenAuth {
         }
 
         String token = authHeader.substring(7);
-        String username = jwtUtil.extractUsername(token);
+        String username;
+        try {
+            username = jwtUtil.extractUsername(token);
+        } catch (ExpiredJwtException e) {
+            throw new IllegalArgumentException("토큰이 만료되었습니다.");
+        }
 
         if (username == null) {
             throw new IllegalArgumentException("유효하지 않은 토큰입니다.");


### PR DESCRIPTION
### 토큰 인증 관련

토큰이 만료되면 `extractClaims` 메서드에서 `ExpiredJwtException` 예외를 던집니다.
토큰에서 Username을 추출해낼 때마다 확인이 되고 있기 때문에 토큰이 만료됐는지 개별적으로 확인할 필요는 없을 것 같아요.
그래서 `isTokenExpired` 메서드와 `validateToken` 메서드를 지웠습니다.

토큰이 만료되면 발생하는 `ExpiredJwtException` 예외를 던지면 
받아주는 `catch (ExpiredJwtException e)`를 `extractUsernameFromToken()`에 추가했습니다.

### 패키지 제거

사용하지 않는 markdown 패키지와 mybatis 패키지를 제거했습니다.