### PR TITLE
자동 DB 초기화

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,7 @@ spring:
         show_sql: 'true'
     hibernate:
       ddl-auto: update
+    defer-datasource-initialization: true
     show-sql: 'false'
   datasource:
     driverClassName: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
@@ -29,6 +30,9 @@ spring:
   devtools:
     restart:
       enabled: 'true'
+  sql:
+    init:
+      mode: always
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,9 +29,6 @@ spring:
   devtools:
     restart:
       enabled: 'true'
-mybatis:
-  type-aliases-package: com.sesac.carematching
-  mapper-locations: classpath:mapper/**/*.xml
 
 springdoc:
   api-docs:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,10 @@
+/* MariaDB init SQL */
+
+/* Initialize ROLE Table */
+INSERT IGNORE INTO role (rno, rname) VALUES (1, 'ROLE_ADMIN');
+INSERT IGNORE INTO role (rno, rname) VALUES (2, 'ROLE_USER_CAREGIVER');
+INSERT IGNORE INTO role (rno, rname) VALUES (3, 'ROLE_USER');
+
+/* Initialize COMMUNITY_CATEGORY Table */
+INSERT IGNORE INTO community_category (cpcno, name, access) VALUES (1, 'ALL' , '전체');
+INSERT IGNORE INTO community_category (cpcno, name, access) VALUES (2, 'CAREGIVER', '요양사');


### PR DESCRIPTION
@jeeyun2 @jinwon0988 @alljju 
데이터베이스에 초기값이 필요한 경우, 앞으로는 꼭 `data.sql`에 초기값을 입력해주는 SQL을 작성해주세요.

`INSERT IGNORE INTO` 사용하면 제약조건 충돌이 일어날 경우는 `INSERT` 하지 않습니다. 중복 검사 방법은 여러가지가 있지만 우리는 초기값들이 아직 단순한 상황이라 IGNORE 정도로 쉽게 관리해도 괜찮은 상황이라고 생각해요.