### PR TITLE
프로필 수정 기능 추가

### DIFF
--- a/src/main/java/com/sesac/carematching/community/comment/Comment.java
+++ b/src/main/java/com/sesac/carematching/community/comment/Comment.java
@@ -52,9 +52,4 @@ public class Comment {
     @Column(name = "CREATED_AT", nullable = false)
     private Instant createdAt;
 
-    @NotNull
-    @LastModifiedDate
-    @Column(name = "UPDATED_AT", nullable = false)
-    private Instant updatedAt;
-
 }

--- a/src/main/java/com/sesac/carematching/community/comment/CommentResponse.java
+++ b/src/main/java/com/sesac/carematching/community/comment/CommentResponse.java
@@ -17,7 +17,8 @@ public class CommentResponse {
 
     public CommentResponse(Comment comment, Integer postId, User user, boolean isAuthor) {
         this.id = comment.getId();
-        this.profileImage = comment.getIsAnonymous() ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : "작성자 프로필 이미지 url";
+
+        this.profileImage = (comment.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
         this.nickname = comment.getIsAnonymous() ? "익명" : user.getNickname();
         if(user.getRole().getId() == 1) {
             this.role = "관리자";

--- a/src/main/java/com/sesac/carematching/community/comment/CommentResponse.java
+++ b/src/main/java/com/sesac/carematching/community/comment/CommentResponse.java
@@ -1,5 +1,6 @@
 package com.sesac.carematching.community.comment;
 
+import com.sesac.carematching.config.EnvProperties;
 import com.sesac.carematching.user.User;
 import lombok.Getter;
 
@@ -15,12 +16,16 @@ public class CommentResponse {
     private Instant createdAt;
     private boolean isAuthor;
 
-    public CommentResponse(Comment comment, Integer postId, User user, boolean isAuthor) {
+    public CommentResponse(Comment comment, User user, boolean isAuthor) {
         this.id = comment.getId();
 
-        this.profileImage = (comment.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
-        this.nickname = comment.getIsAnonymous() ? "익명" : user.getNickname();
-        if(user.getRole().getId() == 1) {
+        String bucketName = EnvProperties.getS3BucketName();
+
+        this.profileImage = (comment.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty())
+            ? "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png"
+            : user.getProfileImage();        this.nickname = comment.getIsAnonymous() ? "익명" : user.getNickname();
+
+            if(user.getRole().getId() == 1) {
             this.role = "관리자";
         }else if(user.getRole().getId() == 2) {
             this.role = "요양사";

--- a/src/main/java/com/sesac/carematching/community/comment/CommentService.java
+++ b/src/main/java/com/sesac/carematching/community/comment/CommentService.java
@@ -41,7 +41,7 @@ public class CommentService {
         Comment savedComment = commentRepository.save(comment);
 
         // 새 댓글은 현재 로그인한 사용자가 작성했으므로 isAuthor 값은 true로 설정
-        return new CommentResponse(savedComment, post.getId(), user, true);
+        return new CommentResponse(savedComment, user, true);
     }
 
     /**
@@ -58,7 +58,7 @@ public class CommentService {
         // 각 댓글마다 현재 사용자가 작성자인지 여부를 판단 후 CommentResponse로 변환
         return commentPage.map(comment -> {
             boolean isAuthor = comment.getUser().getId().equals(currentUser.getId());
-            return new CommentResponse(comment, post.getId(), comment.getUser(), isAuthor);
+            return new CommentResponse(comment, comment.getUser(), isAuthor);
         });
     }
 

--- a/src/main/java/com/sesac/carematching/community/post/CommunityPostDetailResponse.java
+++ b/src/main/java/com/sesac/carematching/community/post/CommunityPostDetailResponse.java
@@ -24,7 +24,7 @@ public class CommunityPostDetailResponse {
 
     public CommunityPostDetailResponse(Post post, User user, int viewCount, int likeCount, int commentCount, boolean isLiked, boolean isAuthor) {
         this.postId = post.getId();
-        this.profileImage = "작성자 프로필 이미지 url";
+        this.profileImage = (post.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
         this.nickname = post.getIsAnonymous() ? "익명" : user.getNickname();
         if(user.getRole().getId() == 1) {
             this.role = "관리자";

--- a/src/main/java/com/sesac/carematching/community/post/CommunityPostDetailResponse.java
+++ b/src/main/java/com/sesac/carematching/community/post/CommunityPostDetailResponse.java
@@ -1,5 +1,6 @@
 package com.sesac.carematching.community.post;
 
+import com.sesac.carematching.config.EnvProperties;
 import com.sesac.carematching.user.User;
 import lombok.Getter;
 
@@ -24,7 +25,10 @@ public class CommunityPostDetailResponse {
 
     public CommunityPostDetailResponse(Post post, User user, int viewCount, int likeCount, int commentCount, boolean isLiked, boolean isAuthor) {
         this.postId = post.getId();
-        this.profileImage = (post.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
+
+        String bucketName = EnvProperties.getS3BucketName();
+        this.profileImage = (post.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
+
         this.nickname = post.getIsAnonymous() ? "익명" : user.getNickname();
         if(user.getRole().getId() == 1) {
             this.role = "관리자";

--- a/src/main/java/com/sesac/carematching/community/post/CommunityPostListResponse.java
+++ b/src/main/java/com/sesac/carematching/community/post/CommunityPostListResponse.java
@@ -1,5 +1,6 @@
 package com.sesac.carematching.community.post;
 
+import com.sesac.carematching.config.EnvProperties;
 import com.sesac.carematching.user.User;
 import lombok.Getter;
 
@@ -21,7 +22,10 @@ public class CommunityPostListResponse {
         this.title = post.getTitle();
         this.content = post.getContent();
         this.image = post.getImage();
-        this.profileImage = (post.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
+
+        String bucketName = EnvProperties.getS3BucketName();
+        this.profileImage = (post.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
+
         this.nickname = post.getIsAnonymous() ? "익명" : user.getNickname();
         this.relativeTime = relativeTime;
         this.viewCount = viewCount;

--- a/src/main/java/com/sesac/carematching/community/post/CommunityPostListResponse.java
+++ b/src/main/java/com/sesac/carematching/community/post/CommunityPostListResponse.java
@@ -21,7 +21,7 @@ public class CommunityPostListResponse {
         this.title = post.getTitle();
         this.content = post.getContent();
         this.image = post.getImage();
-        this.profileImage = "사용자 프로필 이미지 url";  // 실제로는 User 엔티티에 profileImage 필드를 추가한 뒤 활용
+        this.profileImage = (post.getIsAnonymous() || user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
         this.nickname = post.getIsAnonymous() ? "익명" : user.getNickname();
         this.relativeTime = relativeTime;
         this.viewCount = viewCount;

--- a/src/main/java/com/sesac/carematching/community/post/CommunityUserResponse.java
+++ b/src/main/java/com/sesac/carematching/community/post/CommunityUserResponse.java
@@ -14,7 +14,7 @@ public class CommunityUserResponse {
 
     public CommunityUserResponse(User user, int postCount, int commentCount, int likeCount) {
         this.id = user.getId();
-        this.profileImage = "사용자 프로필 이미지 url";  // 실제로는 User 엔티티에 profileImage 필드를 추가한 뒤 활용
+        this.profileImage = (user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
         this.nickname = user.getNickname();
         this.postCount = postCount;
         this.commentCount = commentCount;

--- a/src/main/java/com/sesac/carematching/community/post/CommunityUserResponse.java
+++ b/src/main/java/com/sesac/carematching/community/post/CommunityUserResponse.java
@@ -1,5 +1,6 @@
 package com.sesac.carematching.community.post;
 
+import com.sesac.carematching.config.EnvProperties;
 import com.sesac.carematching.user.User;
 import lombok.Getter;
 
@@ -14,7 +15,10 @@ public class CommunityUserResponse {
 
     public CommunityUserResponse(User user, int postCount, int commentCount, int likeCount) {
         this.id = user.getId();
-        this.profileImage = (user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://test-carematching-uploaded-files.s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
+
+        String bucketName = EnvProperties.getS3BucketName();
+        this.profileImage = (user.getProfileImage() == null || user.getProfileImage().isEmpty()) ? "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/user_profile_image/basicprofileimage.png" : user.getProfileImage();
+
         this.nickname = user.getNickname();
         this.postCount = postCount;
         this.commentCount = commentCount;

--- a/src/main/java/com/sesac/carematching/config/EnvProperties.java
+++ b/src/main/java/com/sesac/carematching/config/EnvProperties.java
@@ -1,0 +1,24 @@
+package com.sesac.carematching.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class EnvProperties {
+    @Value("${cloud.aws.s3.bucket}")
+    private String s3BucketName;
+
+    private static String s3BucketNameStatic;
+
+    @PostConstruct
+    public void init() {
+        s3BucketNameStatic = s3BucketName;
+    }
+
+    public static String getS3BucketName() {
+        return s3BucketNameStatic;
+    }
+}

--- a/src/main/java/com/sesac/carematching/user/User.java
+++ b/src/main/java/com/sesac/carematching/user/User.java
@@ -41,6 +41,10 @@ public class User {
     @Column(name = "PASSWORD", nullable = false)
     private String password;
 
+    @Size(max = 1000)
+    @Column(name = "PROFILE_IMAGE")
+    private String profileImage;
+
     @Size(max = 50)
     @NotNull
     @Column(name = "NICKNAME", nullable = false, length = 50)

--- a/src/main/java/com/sesac/carematching/user/UserController.java
+++ b/src/main/java/com/sesac/carematching/user/UserController.java
@@ -3,13 +3,17 @@ package com.sesac.carematching.user;
 import com.sesac.carematching.user.dto.UserSignupDTO;
 import com.sesac.carematching.user.dto.UserUpdateDTO;
 import com.sesac.carematching.user.dto.UsernameDTO;
+import com.sesac.carematching.util.S3UploadService;
 import com.sesac.carematching.util.TokenAuth;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,6 +24,7 @@ public class UserController {
 
     private final UserService userService;
     private final TokenAuth tokenAuth;
+    private final S3UploadService s3UploadService;
 
     @PostMapping("/signup")
     public ResponseEntity<Void> join(@RequestBody UserSignupDTO user) {
@@ -102,6 +107,35 @@ public class UserController {
                 .body("처리하는 도중 오류가 발생했습니다.");
         }
     }
+
+    @PostMapping(value = "/update/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> updateProfileImage(HttpServletRequest request,
+                                                @RequestPart("imageFile") MultipartFile imageFile) {
+        // 1) 토큰에서 사용자 이름 추출 후 사용자 정보 조회
+        String username = tokenAuth.extractUsernameFromToken(request);
+        try {
+            User user = userService.getUserInfo(username);
+            if (imageFile == null || imageFile.isEmpty()) {
+                return ResponseEntity.badRequest().body("이미지 파일을 첨부해주세요.");
+            }
+            // 2) 기존 프로필 이미지가 있다면 S3에서 삭제 (옵션)
+            if (user.getProfileImage() != null && !user.getProfileImage().isEmpty()) {
+                s3UploadService.deleteProfileImageFile(user.getProfileImage());
+            }
+            // 3) 새 프로필 이미지 S3 업로드 후 URL 반환
+            String newProfileImageUrl = s3UploadService.saveProfileImageFile(imageFile);
+            // 4) DB의 프로필 이미지 URL 업데이트
+            userService.updateProfileImage(username, newProfileImageUrl);
+            // 5) 성공 응답 (새로운 프로필 이미지 URL 반환)
+            Map<String, String> response = new HashMap<>();
+            response.put("profileImage", newProfileImageUrl);
+            return ResponseEntity.ok(response);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("프로필 이미지 업데이트 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {

--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -135,4 +135,13 @@ public class UserService {
         return 0;
     }
 
+    @Transactional
+    public void updateProfileImage(String username, String newImageUrl) {
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        user.setProfileImage(newImageUrl);
+        userRepository.save(user);
+    }
+
+
 }

--- a/src/main/java/com/sesac/carematching/util/S3UploadService.java
+++ b/src/main/java/com/sesac/carematching/util/S3UploadService.java
@@ -74,4 +74,19 @@ public class S3UploadService {
         // 업로드된 이미지의 URL 반환
         return amazonS3.getUrl(bucket, fileKey).toString();
     }
+
+    public void deleteProfileImageFile(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty()) {
+            return;
+        }
+
+        try {
+            URL url = new URL(fileUrl);
+            // URL 경로에서 선행 "/"를 제거하고 URL 디코딩
+            String key = URLDecoder.decode(url.getPath().substring(1), StandardCharsets.UTF_8);
+            amazonS3.deleteObject(bucket, key);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/com/sesac/carematching/util/S3UploadService.java
+++ b/src/main/java/com/sesac/carematching/util/S3UploadService.java
@@ -51,10 +51,27 @@ public class S3UploadService {
             URL url = new URL(fileUrl);
             // URL 경로에서 선행 "/"를 제거하고 URL 디코딩
             String key = URLDecoder.decode(url.getPath().substring(1), StandardCharsets.UTF_8);
-            System.out.println("Deleting " + key);
             amazonS3.deleteObject(bucket, key);
         } catch (MalformedURLException e) {
             e.printStackTrace();
         }
+    }
+
+    public String saveProfileImageFile(MultipartFile multipartFile) throws IOException {
+        // 원본 파일명
+        String originalFilename = multipartFile.getOriginalFilename();
+        // UUID와 원본 파일명을 조합하고 "community_image/" 폴더를 prefix로 사용
+        String uniqueFileName = UUID.randomUUID().toString() + "_" + originalFilename;
+        String fileKey = "user_profile_image/" + uniqueFileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        // S3에 객체 업로드
+        amazonS3.putObject(bucket, fileKey, multipartFile.getInputStream(), metadata);
+
+        // 업로드된 이미지의 URL 반환
+        return amazonS3.getUrl(bucket, fileKey).toString();
     }
 }


### PR DESCRIPTION
* `User` 엔티티에 `profileImage`를 추가했습니다.
* S3 bucket에 따라 기본 이미지 사용을 위해 `EnvProperties`를 추가했습니다.
* 프로필 수정 또는 익명일 경우 api에서 기본이미지를 보내도록 수정했습니다.(추후에 프론트에서 익명과 기본이미지를 처리하도록 수정 예정)
* 마이페이지에서 프로필 수정 기능을 추가했습니다.(프로필 수정 후 기본이미지로 돌아오지 못함)