### PR TITLE
Add Room build exception

### DIFF
--- a/src/main/java/com/sesac/carematching/chat/RoomBuildException.java
+++ b/src/main/java/com/sesac/carematching/chat/RoomBuildException.java
@@ -1,0 +1,7 @@
+package com.sesac.carematching.chat;
+
+public class RoomBuildException extends RuntimeException {
+    public RoomBuildException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sesac/carematching/chat/service/RoomServiceImpl.java
+++ b/src/main/java/com/sesac/carematching/chat/service/RoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.sesac.carematching.chat.service;
 
 import com.sesac.carematching.caregiver.Caregiver;
 import com.sesac.carematching.caregiver.CaregiverRepository;
+import com.sesac.carematching.chat.RoomBuildException;
 import com.sesac.carematching.chat.dto.MessageResponse;
 import com.sesac.carematching.chat.dto.RoomResponse;
 import com.sesac.carematching.chat.message.Message;
@@ -37,22 +38,22 @@ public class RoomServiceImpl implements RoomService {
     public RoomResponse createRoom(String requesterUsername, Integer caregiverId) {
         // (1) 요청자 조회
         User requester = userRepository.findByUsername(requesterUsername)
-            .orElseThrow(() -> new IllegalArgumentException("요청자 정보가 존재하지 않습니다."));
+            .orElseThrow(() -> new RoomBuildException("요청자 정보가 존재하지 않습니다."));
 
         // (2) 요청자가 요양사이면 에러
         if (caregiverRepository.existsByUser(requester)) {
-            throw new SecurityException("요양사는 요청자가 될 수 없습니다.");
+            throw new RoomBuildException("요양사는 요청자가 될 수 없습니다.");
         }
 
         // (3) caregiverId로 수신자(Caregiver) 조회 → receiver(User)
         Caregiver caregiver = caregiverRepository.findById(caregiverId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 요양사입니다."));
+            .orElseThrow(() -> new RoomBuildException("존재하지 않는 요양사입니다."));
         User receiver = caregiver.getUser();
 
         // (4) 중복된 방이 있는지 확인
         boolean roomExists = roomRepository.existsByRequesterAndReceiver(requester, receiver);
         if (roomExists) {
-            throw new IllegalStateException("이미 해당 요양사와 채팅방이 존재합니다.");
+            throw new RoomBuildException("이미 해당 요양사와 채팅방이 존재합니다.");
         }
 
         // (5) 방 생성

--- a/src/main/java/com/sesac/carematching/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/sesac/carematching/config/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.sesac.carematching.config;
 
+import com.sesac.carematching.chat.RoomBuildException;
 import com.sesac.carematching.user.AdminAuthException;
 import com.sesac.carematching.util.TokenAuthException;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -41,6 +43,18 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("status", "error");
+        errorResponse.put("message", ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * RoomBuildException 처리  (400 Bad Request)
+     */
+    @ExceptionHandler(RoomBuildException.class)
+    public ResponseEntity<Map<String, String>> handleSecurityException(SecurityException ex) {
         Map<String, String> errorResponse = new HashMap<>();
         errorResponse.put("status", "error");
         errorResponse.put("message", ex.getMessage());


### PR DESCRIPTION
`Room` 생성할 때 에러 메시지가 프로덕션 환경에서 넘어가지 않음. 
모든 종류의 에러 메시지가 프론트에 전달되는 것은 별로 좋지 않기 때문에
`RoomBuildException`을 따로 만들어서 넘겨주고 싶은 에러 메시지만 골라서 넘겨주었음.