### PR TITLE
fix: 결제 대기 처리 최대 스레드 풀 크기를 128에서 20으로 수정

### DIFF
--- a/src/main/java/com/sesac/carematching/config/AsyncConfig.java
+++ b/src/main/java/com/sesac/carematching/config/AsyncConfig.java
@@ -12,7 +12,7 @@ public class AsyncConfig {
     public ThreadPoolTaskExecutor pendingPaymentRetryExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(0);
-        executor.setMaxPoolSize(128);
+        executor.setMaxPoolSize(20);
         executor.setQueueCapacity(1000);
         executor.setThreadNamePrefix("RetryPending-");
         executor.setKeepAliveSeconds(60);


### PR DESCRIPTION
### 변경 사항
pendingPayment 처리를 위한 Executor의 스레드풀 크기를 20으로 변경

### 참고
Spring의 기본 스레드풀 크기: 200

Spring 스레드풀 크기의 10% 크기로 할당해 Spring 웹서비스 안정성을 해치지 않도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tuned background retry processing concurrency to improve stability under high load, reducing resource spikes and timeouts.
  * Provides more predictable throughput for pending payment retries, leading to smoother performance during peak activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->