### PR TITLE
refactor: PG 추상화 누수 제거 — 결제 승인 요청 구성 책임을 각 PG 구현체로 이동

### DIFF
--- a/src/main/java/com/sesac/carematching/transaction/TransactionConfirmFacade.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionConfirmFacade.java
@@ -1,7 +1,6 @@
 package com.sesac.carematching.transaction;
 
 import com.sesac.carematching.transaction.dto.TransactionConfirmDTO;
-import com.sesac.carematching.transaction.exception.PaymentVerificationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,12 +17,14 @@ public class TransactionConfirmFacade {
         try {
             // 내부적으로 트랜잭션이 시작되고 정상 완료 시 커밋됨
             return transactionService.confirmTransaction(transactionConfirmDTO, userId, paymentKey);
-        } catch (PaymentVerificationException e) {
-            // PG사 승인 실패 등 명확한 결제 검증 예외 발생 시 내부 트랜잭션은 롤백 완료됨
-            log.warn("[결제 검증 실패] orderId: {}, 사유: {}", transactionConfirmDTO.getOrderId(), e.getMessage());
+        } catch (IllegalStateException e) {
+            // 사전 검증 실패(이미 승인된 거래, PG 미선택 등)는 결제 시도 전이므로 FAILED 처리하지 않음
+            throw e;
+        } catch (Exception e) {
+            // PG 승인 실패, 네트워크 오류 등 결제 진행 중 예외 발생 시 FAILED 기록
+            log.warn("[결제 실패] orderId: {}, 사유: {}", transactionConfirmDTO.getOrderId(), e.getMessage());
             transactionService.markAsFailed(transactionConfirmDTO.getOrderId());
-
-            throw e; // 글로벌 예외 처리기에서 응답을 생성하도록 다시 던짐
+            throw e;
         }
     }
 }

--- a/src/main/java/com/sesac/carematching/transaction/TransactionConfirmFacade.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionConfirmFacade.java
@@ -1,0 +1,29 @@
+package com.sesac.carematching.transaction;
+
+import com.sesac.carematching.transaction.dto.TransactionConfirmDTO;
+import com.sesac.carematching.transaction.exception.PaymentVerificationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TransactionConfirmFacade {
+
+    private final TransactionService transactionService;
+
+    // 트랜잭션 어노테이션을 걸지 않아 순수하게 흐름만 제어합니다.
+    public TransactionConfirmDTO confirmTransaction(TransactionConfirmDTO transactionConfirmDTO, Integer userId, String paymentKey) {
+        try {
+            // 내부적으로 트랜잭션이 시작되고 정상 완료 시 커밋됨
+            return transactionService.confirmTransaction(transactionConfirmDTO, userId, paymentKey);
+        } catch (PaymentVerificationException e) {
+            // PG사 승인 실패 등 명확한 결제 검증 예외 발생 시 내부 트랜잭션은 롤백 완료됨
+            log.warn("[결제 검증 실패] orderId: {}, 사유: {}", transactionConfirmDTO.getOrderId(), e.getMessage());
+            transactionService.markAsFailed(transactionConfirmDTO.getOrderId());
+
+            throw e; // 글로벌 예외 처리기에서 응답을 생성하도록 다시 던짐
+        }
+    }
+}

--- a/src/main/java/com/sesac/carematching/transaction/TransactionController.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class TransactionController {
 
     private final TransactionService transactionService;
+    private final TransactionConfirmFacade transactionConfirmFacade; // 결제 승인 흐름 제어용 파사드
     private final TokenAuth tokenAuth;
 
     @Operation(summary = "거래 생성", description = "돌봄이와 회원 간의 거래를 생성합니다.")
@@ -65,6 +66,6 @@ public class TransactionController {
     @PostMapping("/verify/{paymentKey}")
     public ResponseEntity<TransactionConfirmDTO> confirmPayment(@RequestBody TransactionConfirmDTO transactionConfirmDTO, @PathVariable String paymentKey, HttpServletRequest request) {
         Integer userId = tokenAuth.extractUserIdFromToken(request);
-        return ResponseEntity.ok().body(transactionService.confirmTransaction(transactionConfirmDTO, userId, paymentKey));
+        return ResponseEntity.ok().body(transactionConfirmFacade.confirmTransaction(transactionConfirmDTO, userId, paymentKey));
     }
 }

--- a/src/main/java/com/sesac/carematching/transaction/TransactionService.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionService.java
@@ -186,14 +186,17 @@ public class TransactionService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markAsFailed(String orderId) {
-        transactionRepository.findByOrderId(orderId).ifPresent(transaction -> {
-            try {
+        try {
+            transactionRepository.findByOrderId(orderId).ifPresent(transaction -> {
                 // 도메인 엔티티(Transaction) 내부의 상태 전이(FSM) 방어 로직을 전적으로 신뢰합니다.
                 transaction.changeTransactionStatus(TransactionStatus.FAILED);
-            } catch (IllegalTransactionStateException e) {
-                // 상태 전이 불가 예외가 발생한 경우(이미 처리 완료 등) 조용히 무시하고 로그만 남깁니다.
-                log.warn("[상태 변경 무시] orderId: {}, 현재 상태: {}, 사유: {}", orderId, transaction.getTransactionStatus(), e.getMessage());
-            }
-        });
+            });
+        } catch (IllegalTransactionStateException e) {
+            // 상태 전이 불가 예외가 발생한 경우(이미 처리 완료 등) 조용히 무시하고 로그만 남깁니다.
+            log.warn("[상태 변경 무시] orderId: {}, 사유: {}", orderId, e.getMessage());
+        } catch (Exception e) {
+            // DB 오류 등 예기치 못한 예외 발생 시 원래 예외를 덮지 않도록 로그만 남깁니다.
+            log.error("[FAILED 기록 실패] orderId: {}", orderId, e);
+        }
     }
 }

--- a/src/main/java/com/sesac/carematching/transaction/TransactionService.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionService.java
@@ -136,40 +136,9 @@ public class TransactionService {
             throw new IllegalStateException("결제 수단(PG사)이 선택되지 않았습니다. selectPg API를 먼저 호출해주세요.");
         }
 
-        // 현재 결제의 PG사에 알맞는 confirmRequestDTO 생성
-        PaymentConfirmRequestDTO request;
-        TransactionDetailDTO transactionDetailDTO;
         PaymentService paymentService = paymentServiceFactory.getService(pg);
-
-        if (pg == PaymentProvider.TOSS) {
-            // 토스페이먼츠는 자체적으로 결제 가격 확인 과정 추가
-            if (!transactionConfirmDTO.getPrice().equals(transaction.getPrice())) {
-                transaction.changeTransactionStatus(TransactionStatus.FAILED);
-                throw new IllegalStateException("잘못된 금액이 결제되었습니다. 다시 주문 해주세요.");
-            }
-            request = PaymentConfirmRequestDTO.builder()
-                .orderId(orderId)
-                .amount(transaction.getPrice())
-                .paymentKey(paymentKey)
-                .build();
-        } else if (pg == PaymentProvider.KAKAO) {
-            // 카카오는 추가 정보 필요
-            String pgToken = transactionConfirmDTO.getPgToken();
-            if (pgToken == null) {
-                throw new IllegalArgumentException("KakaoPay 결제시 pgToken은 필수값입니다.");
-            }
-            request = PaymentConfirmRequestDTO.builder()
-                .orderId(orderId)
-                .amount(transaction.getPrice())
-                .paymentKey(paymentKey)
-                .partnerUserId(userId.toString()) // 카카오: userId 추가 필요
-                .pgToken(pgToken) // 카카오: pgToken 추가 필요
-                .build();
-        } else {
-            throw new UnsupportedOperationException("confirm이 지원되지 않는 PG사: " + pg);
-        }
-
-        transactionDetailDTO = paymentService.confirmPayment(request);
+        PaymentConfirmRequestDTO request = paymentService.buildConfirmRequest(transaction, transactionConfirmDTO, paymentKey);
+        TransactionDetailDTO transactionDetailDTO = paymentService.confirmPayment(request);
         // DONE: 인증된 결제수단으로 요청한 결제가 승인된 상태입니다. (https://docs.tosspayments.com/reference#payment-%EA%B0%9D%EC%B2%B4)
         // KakaoPay 응답도 승인 성공시 자체적으로 Status를 DONE으로 설정하였음
         if (transactionDetailDTO.getPgStatus() != PgStatus.DONE)

--- a/src/main/java/com/sesac/carematching/transaction/TransactionService.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionService.java
@@ -2,6 +2,8 @@ package com.sesac.carematching.transaction;
 
 import com.sesac.carematching.caregiver.Caregiver;
 import com.sesac.carematching.caregiver.CaregiverService;
+import com.sesac.carematching.transaction.exception.PaymentVerificationException;
+import com.sesac.carematching.transaction.exception.IllegalTransactionStateException;
 import com.sesac.carematching.transaction.dto.*;
 import com.sesac.carematching.transaction.payment.*;
 import com.sesac.carematching.user.User;
@@ -12,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 
 @Slf4j
 @Service
@@ -141,8 +144,9 @@ public class TransactionService {
         TransactionDetailDTO transactionDetailDTO = paymentService.confirmPayment(request);
         // DONE: 인증된 결제수단으로 요청한 결제가 승인된 상태입니다. (https://docs.tosspayments.com/reference#payment-%EA%B0%9D%EC%B2%B4)
         // KakaoPay 응답도 승인 성공시 자체적으로 Status를 DONE으로 설정하였음
-        if (transactionDetailDTO.getPgStatus() != PgStatus.DONE)
-            throw new RuntimeException("결제 승인에 실패했습니다.");
+        if (transactionDetailDTO.getPgStatus() != PgStatus.DONE) {
+            throw new PaymentVerificationException("결제 승인에 실패했습니다. (상태: " + transactionDetailDTO.getPgStatus() + ")");
+        }
 
         transaction.setPgPaymentKey(transactionDetailDTO.getPaymentKey());
         transaction.setOrderName(transactionDetailDTO.getOrderName());
@@ -178,5 +182,18 @@ public class TransactionService {
         return transaction.getTransactionStatus() != TransactionStatus.SUCCESS &&
             transaction.getTransactionStatus() != TransactionStatus.CANCELED &&
             transaction.getTransactionStatus() != TransactionStatus.REFUNDED;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAsFailed(String orderId) {
+        transactionRepository.findByOrderId(orderId).ifPresent(transaction -> {
+            try {
+                // 도메인 엔티티(Transaction) 내부의 상태 전이(FSM) 방어 로직을 전적으로 신뢰합니다.
+                transaction.changeTransactionStatus(TransactionStatus.FAILED);
+            } catch (IllegalTransactionStateException e) {
+                // 상태 전이 불가 예외가 발생한 경우(이미 처리 완료 등) 조용히 무시하고 로그만 남깁니다.
+                log.warn("[상태 변경 무시] orderId: {}, 현재 상태: {}, 사유: {}", orderId, transaction.getTransactionStatus(), e.getMessage());
+            }
+        });
     }
 }

--- a/src/main/java/com/sesac/carematching/transaction/exception/PaymentVerificationException.java
+++ b/src/main/java/com/sesac/carematching/transaction/exception/PaymentVerificationException.java
@@ -1,0 +1,7 @@
+package com.sesac.carematching.transaction.exception;
+
+public class PaymentVerificationException extends RuntimeException {
+    public PaymentVerificationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sesac/carematching/transaction/exception/TransactionExceptionHandler.java
+++ b/src/main/java/com/sesac/carematching/transaction/exception/TransactionExceptionHandler.java
@@ -24,4 +24,12 @@ public class TransactionExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
+    @ExceptionHandler(PaymentVerificationException.class)
+    public ResponseEntity<?> handlePaymentVerificationException(PaymentVerificationException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("status", "error");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
 }

--- a/src/main/java/com/sesac/carematching/transaction/payment/AbstractPaymentService.java
+++ b/src/main/java/com/sesac/carematching/transaction/payment/AbstractPaymentService.java
@@ -6,6 +6,8 @@ import com.sesac.carematching.transaction.Transaction;
 import com.sesac.carematching.transaction.TransactionRepository;
 import com.sesac.carematching.transaction.TransactionStatus;
 import com.sesac.carematching.transaction.dto.PaymentConfirmRequestDTO;
+import com.sesac.carematching.transaction.dto.PaymentReadyRequestDTO;
+import com.sesac.carematching.transaction.dto.PaymentReadyResponseDTO;
 import com.sesac.carematching.transaction.dto.TransactionDetailDTO;
 import com.sesac.carematching.transaction.payment.pendingPayment.PendingPayment;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,37 @@ public abstract class AbstractPaymentService implements PaymentService{
             log.warn("{} 파싱 실패: {}", valueType.getSimpleName(), errorJson, e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * 결제 준비 단계가 필요 없는 PG사를 위한 기본 구현입니다.
+     * 결제 준비가 필요한 PG사(예: KakaoPay)에서는 이 메서드를 오버라이드해야 합니다.
+     */
+    @Override
+    public PaymentReadyResponseDTO readyPayment(PaymentReadyRequestDTO request) {
+        return new PaymentReadyResponseDTO();
+    }
+
+    /**
+     * 결제 준비 헬스체크가 필요 없는 PG사를 위한 기본 구현입니다.
+     * 결제 준비 헬스체크가 필요한 PG사(예: KakaoPay)에서는 이 메서드를 오버라이드해야 합니다.
+     */
+    @Override
+    public void healthCheckReady(PaymentReadyRequestDTO request) {
+        // no-op
+    }
+
+    /**
+     * PendingPayment 재시도 시 공통 필드(orderId, amount, paymentKey)만으로 요청을 구성합니다.
+     * PG사별 추가 필드가 필요한 경우(예: KakaoPay의 pgToken) 오버라이드하세요.
+     */
+    @Override
+    public PaymentConfirmRequestDTO buildRetryConfirmRequest(Transaction transaction) {
+        return PaymentConfirmRequestDTO.builder()
+            .orderId(transaction.getOrderId())
+            .amount(transaction.getPrice())
+            .paymentKey(transaction.getPgPaymentKey())
+            .build();
     }
 
     /**

--- a/src/main/java/com/sesac/carematching/transaction/payment/PaymentService.java
+++ b/src/main/java/com/sesac/carematching/transaction/payment/PaymentService.java
@@ -1,13 +1,14 @@
 package com.sesac.carematching.transaction.payment;
 
+import com.sesac.carematching.transaction.Transaction;
 import com.sesac.carematching.transaction.dto.PaymentReadyRequestDTO;
 import com.sesac.carematching.transaction.dto.PaymentConfirmRequestDTO;
 import com.sesac.carematching.transaction.dto.PaymentReadyResponseDTO;
+import com.sesac.carematching.transaction.dto.TransactionConfirmDTO;
 import com.sesac.carematching.transaction.dto.TransactionDetailDTO;
 
 /**
  * 결제 제공자(예: TossPayments, 다른 PG)들을 추상화한 서비스 인터페이스.
- * 각 PG사에서 지원하지 않는 메서드가 존재할 경우, 구체 클래스에서 UOE를 던져야 함.
  */
 public interface PaymentService {
 
@@ -47,5 +48,24 @@ public interface PaymentService {
      * @param request 주문 승인 정보
      */
     void healthCheckConfirm(PaymentConfirmRequestDTO request);
+
+    /**
+     * PG사에 맞는 결제 승인 요청 DTO를 구성합니다.
+     * 각 PG사마다 필요한 필드가 다르므로, 구현체가 직접 요청을 구성합니다.
+     *
+     * @param transaction  결제 대상 트랜잭션 엔티티
+     * @param clientInput  클라이언트(프론트엔드)에서 전달된 요청 데이터
+     * @param paymentKey   PG사에서 발급한 결제 키
+     * @return 각 PG사에 맞게 구성된 PaymentConfirmRequestDTO
+     */
+    PaymentConfirmRequestDTO buildConfirmRequest(Transaction transaction, TransactionConfirmDTO clientInput, String paymentKey);
+
+    /**
+     * PendingPayment 재시도 시 사용할 결제 승인 요청 DTO를 구성합니다.
+     *
+     * @param transaction  재시도 대상 트랜잭션 엔티티 (PendingPayment 포함)
+     * @return 재시도용 PaymentConfirmRequestDTO
+     */
+    PaymentConfirmRequestDTO buildRetryConfirmRequest(Transaction transaction);
 
 }

--- a/src/main/java/com/sesac/carematching/transaction/payment/pendingPayment/PendingPaymentAsyncProcessor.java
+++ b/src/main/java/com/sesac/carematching/transaction/payment/pendingPayment/PendingPaymentAsyncProcessor.java
@@ -46,19 +46,10 @@ public class PendingPaymentAsyncProcessor {
         }
 
         PaymentProvider nowPg = transaction.getPaymentProvider();
-        PaymentConfirmRequestDTO request = PaymentConfirmRequestDTO.builder()
-                .orderId(transaction.getOrderId())
-                .amount(transaction.getPrice())
-                .paymentKey(transaction.getPgPaymentKey()) // 초기 결제 시도 시 저장된 paymentKey 사용
-                .build();
-
-        if (nowPg == PaymentProvider.KAKAO) {
-            request.setPgToken(pendingPayment.getPgToken());
-            request.setPartnerUserId(pendingPayment.getPartnerUserId());
-        }
+        PaymentService paymentService = this.paymentServices.get(nowPg);
+        PaymentConfirmRequestDTO request = paymentService.buildRetryConfirmRequest(transaction);
 
         try {
-            PaymentService paymentService = this.paymentServices.get(nowPg);
             TransactionDetailDTO transactionDetailDTO = paymentService.confirmPayment(request);
 
             if (transactionDetailDTO.getPgStatus() == PgStatus.DONE) {

--- a/src/main/java/com/sesac/carematching/transaction/payment/provider/kakao/KakaoPayService.java
+++ b/src/main/java/com/sesac/carematching/transaction/payment/provider/kakao/KakaoPayService.java
@@ -77,6 +77,10 @@ public class KakaoPayService extends AbstractPaymentService {
     @Override
     public PaymentConfirmRequestDTO buildRetryConfirmRequest(Transaction transaction) {
         PendingPayment pendingPayment = transaction.getPendingPayment();
+        if (pendingPayment == null) {
+            throw new IllegalStateException(
+                "KakaoPay 재시도에는 PendingPayment가 필요합니다. orderId=" + transaction.getOrderId());
+        }
         return PaymentConfirmRequestDTO.builder()
             .orderId(transaction.getOrderId())
             .amount(transaction.getPrice())

--- a/src/main/java/com/sesac/carematching/transaction/payment/provider/kakao/KakaoPayService.java
+++ b/src/main/java/com/sesac/carematching/transaction/payment/provider/kakao/KakaoPayService.java
@@ -9,6 +9,7 @@ import com.sesac.carematching.transaction.TransactionRepository;
 import com.sesac.carematching.transaction.dto.PaymentConfirmRequestDTO;
 import com.sesac.carematching.transaction.dto.PaymentReadyRequestDTO;
 import com.sesac.carematching.transaction.dto.PaymentReadyResponseDTO;
+import com.sesac.carematching.transaction.dto.TransactionConfirmDTO;
 import com.sesac.carematching.transaction.dto.TransactionDetailDTO;
 import com.sesac.carematching.transaction.payment.AbstractPaymentService;
 import com.sesac.carematching.transaction.payment.PaymentProvider;
@@ -56,6 +57,33 @@ public class KakaoPayService extends AbstractPaymentService {
     @Override
     public PaymentProvider getPaymentProvider() {
         return PaymentProvider.KAKAO;
+    }
+
+    @Override
+    public PaymentConfirmRequestDTO buildConfirmRequest(Transaction transaction, TransactionConfirmDTO clientInput, String paymentKey) {
+        String pgToken = clientInput.getPgToken();
+        if (pgToken == null) {
+            throw new IllegalArgumentException("KakaoPay 결제시 pgToken은 필수값입니다.");
+        }
+        return PaymentConfirmRequestDTO.builder()
+            .orderId(transaction.getOrderId())
+            .amount(transaction.getPrice())
+            .paymentKey(paymentKey)
+            .partnerUserId(transaction.getUno().getId().toString())
+            .pgToken(pgToken)
+            .build();
+    }
+
+    @Override
+    public PaymentConfirmRequestDTO buildRetryConfirmRequest(Transaction transaction) {
+        PendingPayment pendingPayment = transaction.getPendingPayment();
+        return PaymentConfirmRequestDTO.builder()
+            .orderId(transaction.getOrderId())
+            .amount(transaction.getPrice())
+            .paymentKey(transaction.getPgPaymentKey())
+            .pgToken(pendingPayment.getPgToken())
+            .partnerUserId(pendingPayment.getPartnerUserId())
+            .build();
     }
 
     @Override

--- a/src/main/java/com/sesac/carematching/transaction/payment/provider/toss/TossPaymentService.java
+++ b/src/main/java/com/sesac/carematching/transaction/payment/provider/toss/TossPaymentService.java
@@ -4,10 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sesac.carematching.transaction.Transaction;
 import com.sesac.carematching.transaction.TransactionRepository;
+import com.sesac.carematching.transaction.TransactionStatus;
 import com.sesac.carematching.transaction.dto.PaymentConfirmRequestDTO;
-import com.sesac.carematching.transaction.dto.PaymentReadyRequestDTO;
-import com.sesac.carematching.transaction.dto.PaymentReadyResponseDTO;
+import com.sesac.carematching.transaction.dto.TransactionConfirmDTO;
 import com.sesac.carematching.transaction.dto.TransactionDetailDTO;
 import com.sesac.carematching.transaction.payment.AbstractPaymentService;
 import com.sesac.carematching.transaction.payment.PaymentProvider;
@@ -47,13 +48,16 @@ public class TossPaymentService extends AbstractPaymentService {
     }
 
     @Override
-    public PaymentReadyResponseDTO readyPayment(PaymentReadyRequestDTO request) {
-        throw new UnsupportedOperationException("Payment Ready is not supported on Toss Payments");
-    }
-
-    @Override
-    public void healthCheckReady(PaymentReadyRequestDTO request) {
-        throw new UnsupportedOperationException("Payment Ready is not supported on Toss Payments");
+    public PaymentConfirmRequestDTO buildConfirmRequest(Transaction transaction, TransactionConfirmDTO clientInput, String paymentKey) {
+        if (!clientInput.getPrice().equals(transaction.getPrice())) {
+            transaction.changeTransactionStatus(TransactionStatus.FAILED);
+            throw new IllegalStateException("잘못된 금액이 결제되었습니다. 다시 주문 해주세요.");
+        }
+        return PaymentConfirmRequestDTO.builder()
+            .orderId(transaction.getOrderId())
+            .amount(transaction.getPrice())
+            .paymentKey(paymentKey)
+            .build();
     }
 
     @Override

--- a/src/main/java/com/sesac/carematching/transaction/payment/provider/toss/TossPaymentService.java
+++ b/src/main/java/com/sesac/carematching/transaction/payment/provider/toss/TossPaymentService.java
@@ -49,7 +49,7 @@ public class TossPaymentService extends AbstractPaymentService {
 
     @Override
     public PaymentConfirmRequestDTO buildConfirmRequest(Transaction transaction, TransactionConfirmDTO clientInput, String paymentKey) {
-        if (!clientInput.getPrice().equals(transaction.getPrice())) {
+        if (clientInput.getPrice() == null || !clientInput.getPrice().equals(transaction.getPrice())) {
             transaction.changeTransactionStatus(TransactionStatus.FAILED);
             throw new IllegalStateException("잘못된 금액이 결제되었습니다. 다시 주문 해주세요.");
         }


### PR DESCRIPTION
### 변경 내용
1. **`PaymentService` 인터페이스에 두 메서드 추가**
`buildConfirmRequest(transaction, clientInput, paymentKey)` — 최초 결제 승인 요청 구성
`buildRetryConfirmRequest(transaction)` — `PendingPayment` 재시도 요청 구성
2. **`AbstractPaymentService` 기본 구현 추가**
`readyPayment()` / `healthCheckReady()` — 결제 준비 단계가 없는 PG를 위한 no-op 기본 구현 (기존 UOE 방식 개선)
`buildRetryConfirmRequest()` — 공통 필드(orderId, amount, paymentKey)만으로 구성하는 기본 구현
3. **`TossPaymentService`**
`buildConfirmRequest()` 구현 — 가격 검증 로직 포함
`readyPayment()` / `healthCheckReady()` UOE 제거 → 상위 no-op 상속
4. **`KakaoPayService`**
`buildConfirmRequest()` 구현 — pgToken, partnerUserId 처리
`buildRetryConfirmRequest()` 오버라이드 — `PendingPayment`에서 카카오 전용 필드 복원
5. **`TransactionService.confirmTransaction()`**
PG별 if-else 블록 33줄 → 2줄로 축소
6. **`PendingPaymentAsyncProcessor.retrySinglePendingPayment()`**
카카오 여부 분기 제거 → `buildRetryConfirmRequest()` 위임

### 효과
**OCP 준수**: 3번째 PG 추가 시 `TransactionService`, `PendingPaymentAsyncProcessor` 수정 불필요
**ISP 개선**: `UnsupportedOperationException` 대신 no-op 기본 구현으로 런타임 안전성 확보
**단일 책임**: 각 PG가 자신의 요청 형식을 스스로 결정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 결제 확인 흐름 담당 신규 퍼사드 추가로 예외 처리와 실패 마킹 분리
  * 결제 실패를 별도 트랜잭션으로 안전하게 마킹하는 공개 API 추가
  * 결제 검증 실패 전용 예외 도입 및 별도 핸들러 추가

* **Refactor**
  * 결제 확인 요청 생성 책임을 결제 서비스로 위임해 제공자별 구현 분리
  * 재시도 처리 로직 단순화 및 중복 제거

* **Bug Fixes**
  * 금액·토큰 검증 강화로 승인/검증 실패 시 정확한 실패 처리 및 로깅 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->