### PR TITLE
ci: infra:gateway 빌드 추가 및 테스트 활성화

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build with Gradle
-        run: ./gradlew :app:build -x test
+        run: ./gradlew :app:build :infra:gateway:build --parallel
 
       - name: Build Docker Image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## 변경 사항

PR 체크가 `:app`만 빌드하고 `-x test`로 테스트를 건너뛰던 것을, `:app`과 `:infra:gateway` 두 모듈 모두 빌드·테스트하도록 변경했습니다.

```diff
-        run: ./gradlew :app:build -x test
+        run: ./gradlew :app:build :infra:gateway:build --parallel
```

- `infra:gateway` 모듈을 빌드 대상에 추가
- `-x test` 제거 → 두 모듈 모두 테스트 실행
- 두 모듈은 상호 `project(...)` 의존이 없어 `--parallel`로 동시 실행

## 검증

로컬 clean 빌드 통과 (`:app`, `:infra:gateway` 테스트 포함):

```
BUILD SUCCESSFUL in 8s
14 actionable tasks: 14 executed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)